### PR TITLE
Fix generic string delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ up with unescaped content, letting you edit it directly.
 Then press `C-c C-c` to re-escape the content and insert into the
 string, or `C-c C-k` to abort.
 
-Here's [an ascii-cast of it in action](http://ascii.io/a/3040).
+[![asciicast](https://asciinema.org/a/3040.png)](https://asciinema.org/a/3040)
 
 ### JavaScript and HTML
 

--- a/features/string-edit.feature
+++ b/features/string-edit.feature
@@ -124,3 +124,12 @@ Feature: Edit string at point
         "string" +
         "yeah";
     """
+
+  Scenario: Open string in major with with generic string delimiters
+    Given I turn on python-mode
+    And I insert "s = "my string""
+    When I go to the front of the word "string"
+    And I edit the string at point
+    And I type "test"
+    And I press "C-c C-c"
+    Then I should see "s = "my teststring""

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-carton exec ecukes "$@"
+cask exec ecukes "$@"

--- a/string-edit.el
+++ b/string-edit.el
@@ -136,8 +136,11 @@
   (cdr (assoc key map)))
 
 (defun se/current-quotes-char ()
-  "The char that is the current quote delimiter"
-  (nth 3 (syntax-ppss)))
+  "The char that is the current quote delimiter, or nil if not in a string."
+  (let ((delimiter (nth 3 (syntax-ppss))))
+    (cond ((stringp delimiter) delimiter)
+          ;; `syntax-ppss' can return t meaning 'a generic string delimiter'.
+          (delimiter ?\"))))
 
 (defalias 'se/point-inside-string-p 'se/current-quotes-char)
 


### PR DESCRIPTION
string-edit didn't work with python-mode, so I've made the necessary changes to support it. I've also fix a broken link and updated the test script (see the relevant commit messages).