### PR TITLE
Declare buffer local variables as global variable

### DIFF
--- a/string-edit.el
+++ b/string-edit.el
@@ -27,6 +27,9 @@
 
 (require 'dash)
 
+(defvar se/original)
+(defvar se/original-buffer)
+
 ;;;###autoload
 (defun string-edit-at-point ()
   (interactive)


### PR DESCRIPTION
This change fixes following byte-compile warnings.

```
In string-edit-at-point:
string-edit.el:45:34:Warning: assignment to free variable `se/original'
string-edit.el:46:54:Warning: assignment to free variable `se/original-buffer'

In string-edit-conclude:
string-edit.el:57:29:Warning: reference to free variable `se/original'
string-edit.el:61:26:Warning: reference to free variable `se/original-buffer'
```