### PR TITLE
Add a docstring

### DIFF
--- a/string-edit.el
+++ b/string-edit.el
@@ -37,6 +37,8 @@ before the minor mode is enabled.")
 
 ;;;###autoload
 (defun string-edit-at-point ()
+  "Pop up a buffer to edit the string at point.
+This saves you from needing to manually escape characters."
   (interactive)
   (when (se/point-inside-string-p)
     (let* ((p (point))


### PR DESCRIPTION
This is the primary function that users will use, so a basic docstring
is very helpful when users are first using this package.