### PR TITLE
Update define-minor-mode arguments

### DIFF
--- a/string-edit.el
+++ b/string-edit.el
@@ -138,7 +138,9 @@ This saves you from needing to manually escape characters."
 
 (define-minor-mode string-edit-mode
   "Minor mode for useful keybindings while editing string."
-  nil " StringEdit" string-edit-mode-map
+  :init-value nil
+  :lighter " StringEdit"
+  :keymap string-edit-mode-map
   (if string-edit-mode
       (add-hook 'post-command-hook 'se/post-command nil t)
     (remove-hook 'post-command-hook 'se/post-command t)))


### PR DESCRIPTION
A change in how the arguments are used to define the minor mode for
`string-edit-mode` to match the changes to the macro in Emacs 28.1.

Resolves #17